### PR TITLE
Add --no-old-file option parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ i18n.py [OPTIONS] [PATHS...]
 --help, -h : prints this help message
 --recursive, -r : run on all subfolders of paths given
 --installed-mods : run on locally installed modules
+--no-old-file : do not create *.old files
 --verbose, -v : add output information
 ```
 
@@ -41,8 +42,8 @@ This allows for old translations and comments to be reused with new lines where 
 When running on linux to install bash_completion for i18n, you can run
 
 ```
-mkdir -p ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completions/completions
-ln -s $PWD/bash-completions/completions/i18n ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completions/completions/i18n
+mkdir -p ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions
+ln -s $PWD/bash-completion/completions/i18n ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/i18n.py
 ```
 
 This will provide bash autocompletion for this script (you have to run it without using `python3 i18n` command, use `./i18n.py` instead (or `i18n.py` if provided by `$PATH`)).

--- a/bash-completion/completions/i18n
+++ b/bash-completion/completions/i18n
@@ -2,7 +2,7 @@
 _i18n_completions()
 {
 	local cur OPTS_ALL
-	local hasInstalledModOpt hasRecursiveOpt hasVerboseOpt
+	local hasInstalledModOpt hasRecursiveOpt hasVerboseOpt hasNoOldFileOpt
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	for opt in "${COMP_WORDS[@]}"
@@ -20,6 +20,9 @@ _i18n_completions()
 			'-v'|'--verbose')
 				hasVerboseOpt=1
 				;;
+			'--no-old-file')
+				hasNoOldFileOpt=1
+				;;
 
 		esac
 	done
@@ -27,21 +30,41 @@ _i18n_completions()
 		-*)
 			if [ $hasRecursiveOpt ] || [ $hasInstalledModOpt ]
 			then
-				if [ $hasVerboseOpt ]
+				if [ $hasVerboseOpt ] && [ $hasNoOldFileOpt ]
 				then
 					return 0
-				else
+				elif [ $hasNoOldFileOpt ]
+				then
 					OPTS_ALL="--verbose"
+				elif [ $hasVerboseOpt ]
+				then
+					OPTS_ALL="--no-old-file"
+				else
+					OPTS_ALL="--verbose
+						--no-old-file"
 				fi
 			else
-				if [ $hasVerboseOpt ]
+				if [ $hasVerboseOpt ] && [ $hasNoOldFileOpt ]
 				then
 					OPTS_ALL="--installed-mods
 					--recursive"
+				elif [ $hasNoOldFileOpt ]
+				then
+					OPTS_ALL="--help
+						--verbose
+						--installed-mods
+						--recursive"
+				elif [ $hasVerboseOpt ]
+				then
+					OPTS_ALL="--help
+						--installed-mods
+						--no-old-file
+						--recursive"
 				else
 					OPTS_ALL="--help
 						--verbose
 						--installed-mods
+						--no-old-file
 						--recursive"
 				fi
 			fi

--- a/i18n.py
+++ b/i18n.py
@@ -19,13 +19,15 @@ params = {"recursive": False,
     "help": False,
     "mods": False,
     "verbose": False,
-    "folders": []
+    "folders": [],
+    "no-old-file": False
 }
 # Available CLI options
 options = {"recursive": ['--recursive', '-r'],
     "help": ['--help', '-h'],
     "mods": ['--installed-mods'],
-    "verbose": ['--verbose', '-v']
+    "verbose": ['--verbose', '-v'],
+    "no-old-file": ['--no-old-file']
 }
 
 # Strings longer than this will have extra space added between
@@ -64,6 +66,8 @@ DESCRIPTION
         run on all subfolders of paths given
     {', '.join(options["mods"])}
         run on locally installed modules
+    {', '.join(options["no-old-file"])}
+        do not create *.old files
     {', '.join(options["verbose"])}
         add output information
 ''')
@@ -381,7 +385,8 @@ def update_tr_file(dNew, mod_name, tr_file):
 
     if textOld and textOld != textNew:
         print(f"{tr_file} has changed.")
-        shutil.copyfile(tr_file, f"{tr_file}.old")
+        if not params["no-old-file"]:
+            shutil.copyfile(tr_file, f"{tr_file}.old")
 
     with open(tr_file, "w", encoding='utf-8') as new_tr_file:
         new_tr_file.write(textNew)


### PR DESCRIPTION
When you are working with git, it can seems useless to copy old
translations in `*.old` files since we have access to old versions with
git. Using this setting means you do not have to remove `locale/*.old`
files before commit (or to add them to `.gitignore`). By default, `*.old`
files are created (this is opt-in).

Fixes typo in command given for bash_completion in `README.md`.