### PR TITLE
Fix misplaced comment for single character strings

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -118,7 +118,7 @@ pattern_lua_bracketed = re.compile(r'[\.=^\t,{\(\s]N?S\(\s*\[\[(.*?)\]\][\s,\)]'
 # Handles "concatenation" .. " of strings"
 pattern_concat = re.compile(r'["\'][\s]*\.\.[\s]*["\']', re.DOTALL)
 
-pattern_tr = re.compile(r'(.+?[^@])=(.*)')
+pattern_tr = re.compile(r'(.*?[^@])=(.*)')
 pattern_name = re.compile(r'^name[ ]*=[ ]*([^ \n]*)')
 pattern_tr_filename = re.compile(r'\.tr$')
 pattern_po_language_code = re.compile(r'(.*)\.po$')


### PR DESCRIPTION
Makes the `patter_tr` regex match lines with single character strings. This fixes an issue where the comment for a line with a single character before the equals sign was moved below the line it was associated with due to the line not being matched.