### PR TITLE
Add some color on errors and do not display `Done.` if unsuccessful

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -13,6 +13,7 @@
 from __future__ import print_function
 import os, fnmatch, re, shutil, errno
 from sys import argv as _argv
+from sys import stderr as _stderr
 
 # Running params
 params = {"recursive": False,
@@ -404,7 +405,8 @@ def update_mod(folder):
             for tr_file in get_existing_tr_files(folder):
                 update_tr_file(data, modname, os.path.join(folder, "locale/", tr_file))
     else:
-        print("Unable to find modname in folder " + folder)
+        print(f"\033[31mUnable to find modname in folder {folder}.\033[0m", file=_stderr)
+        exit(1)
 
 # Determines if the folder being pointed to is a mod or a mod pack
 # and then runs update_mod accordingly


### PR DESCRIPTION
When running from command line, I often use it with the wrong path, but the previous message is misleading (it ends with "Done.", but nothing is done), so it is better to exit with 1 and to display error message in red.