### PR TITLE
Add more parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ It has the following command line options:
 ```
 i18n.py [OPTIONS] [PATHS...]
 
---help, -h : prints this help message
---recursive, -r : run on all subfolders of paths given
---installed-mods : run on locally installed modules
---no-old-file : do not create *.old files
---verbose, -v : add output information
+--help, -h: prints this help message
+--recursive, -r: run on all subfolders of paths given
+--installed-mods, -m: run on locally installed modules
+--no-old-file, -O: do not create *.old files
+--sort, -s: sort output strings alphabetically
+--break-long-lines, -b: add extra line-breaks before and after long strings
+--verbose, -v: add output information
 ```
 
 The script will preserve any comments in an existing ``template.txt`` or the various ``*.tr`` files, associating them with the line that follows them. So for example:

--- a/bash-completion/completions/i18n
+++ b/bash-completion/completions/i18n
@@ -2,7 +2,7 @@
 _i18n_completions()
 {
 	local cur OPTS_ALL
-	local hasInstalledModOpt hasRecursiveOpt hasVerboseOpt hasNoOldFileOpt
+	local hasInstalledModOpt hasRecursiveOpt hasVerboseOpt hasNoOldFileOpt hasSortOpt hasBreakLongLinesOpt
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	for opt in "${COMP_WORDS[@]}"
@@ -23,51 +23,49 @@ _i18n_completions()
 			'-O'|'--no-old-file')
 				hasNoOldFileOpt=1
 				;;
+			'-s'|'--sort')
+				hasSortOpt=1
+				;;
+			'-b'|'--break-long-lines')
+				hasBreakLongLinesOpt=1
+				;;
 
 		esac
 	done
 	case $cur in
-		-*)
+		-*) # check for words starting with "minus" only
+			OPTS_ALL="--help
+				--installed-mods
+				--recursive
+				--verbose
+				--no-old-file
+				--sort
+				--break-long-lines"
+
+			# recursive and installed-mods
+			# are mutually exclusives
 			if [ $hasRecursiveOpt ] || [ $hasInstalledModOpt ]
 			then
-				if [ $hasVerboseOpt ] && [ $hasNoOldFileOpt ]
-				then
-					return 0
-				elif [ $hasNoOldFileOpt ]
-				then
-					OPTS_ALL="--verbose"
-				elif [ $hasVerboseOpt ]
-				then
-					OPTS_ALL="--no-old-file"
-				else
-					OPTS_ALL="--verbose
-						--no-old-file"
-				fi
-			else
-				if [ $hasVerboseOpt ] && [ $hasNoOldFileOpt ]
-				then
-					OPTS_ALL="--installed-mods
-					--recursive"
-				elif [ $hasNoOldFileOpt ]
-				then
-					OPTS_ALL="--help
-						--verbose
-						--installed-mods
-						--recursive"
-				elif [ $hasVerboseOpt ]
-				then
-					OPTS_ALL="--help
-						--installed-mods
-						--no-old-file
-						--recursive"
-				else
-					OPTS_ALL="--help
-						--verbose
-						--installed-mods
-						--no-old-file
-						--recursive"
-				fi
+				OPTS_ALL=${OPTS_ALL//"--recursive"/}
+				OPTS_ALL=${OPTS_ALL//"--installed-mods"/}
 			fi
+			if [ $hasVerboseOpt ]
+			then
+				OPTS_ALL=${OPTS_ALL//"--verbose"/}
+			fi
+			if [ $hasNoOldFileOpt ]
+			then
+				OPTS_ALL=${OPTS_ALL//"--no-old-file"/}
+			fi
+			if [ $hasSortOpt ]
+			then
+				OPTS_ALL=${OPTS_ALL//"--sort"/}
+			fi
+			if [ $hasBreakLongLinesOpt ]
+			then
+				OPTS_ALL=${OPTS_ALL//"--break-long-lines"/}
+			fi
+
 			COMPREPLY=( $(compgen -W "${OPTS_ALL[*]}" -- $cur) )
 			return 0
 			;;

--- a/bash-completion/completions/i18n
+++ b/bash-completion/completions/i18n
@@ -11,7 +11,7 @@ _i18n_completions()
 			'-h'|'--help')
 				return 0
 				;;
-			'--installed-mods')
+			'-m'|'--installed-mods')
 				hasInstalledModOpt=1
 				;;
 			'-r'|'--recursive')
@@ -20,7 +20,7 @@ _i18n_completions()
 			'-v'|'--verbose')
 				hasVerboseOpt=1
 				;;
-			'--no-old-file')
+			'-O'|'--no-old-file')
 				hasNoOldFileOpt=1
 				;;
 

--- a/i18n.py
+++ b/i18n.py
@@ -27,9 +27,9 @@ params = {"recursive": False,
 # Available CLI options
 options = {"recursive": ['--recursive', '-r'],
     "help": ['--help', '-h'],
-    "mods": ['--installed-mods'],
+    "mods": ['--installed-mods', '-m'],
     "verbose": ['--verbose', '-v'],
-    "no-old-file": ['--no-old-file'],
+    "no-old-file": ['--no-old-file', '-O'],
     "sort": ['--sort', '-s'],
 }
 

--- a/i18n.py
+++ b/i18n.py
@@ -21,14 +21,16 @@ params = {"recursive": False,
     "mods": False,
     "verbose": False,
     "folders": [],
-    "no-old-file": False
+    "no-old-file": False,
+    "sort": False,
 }
 # Available CLI options
 options = {"recursive": ['--recursive', '-r'],
     "help": ['--help', '-h'],
     "mods": ['--installed-mods'],
     "verbose": ['--verbose', '-v'],
-    "no-old-file": ['--no-old-file']
+    "no-old-file": ['--no-old-file'],
+    "sort": ['--sort', '-s'],
 }
 
 # Strings longer than this will have extra space added between
@@ -69,6 +71,8 @@ DESCRIPTION
         run on locally installed modules
     {', '.join(options["no-old-file"])}
         do not create *.old files
+    {', '.join(options["sort"])}
+        sort output strings alphabetically
     {', '.join(options["verbose"])}
         add output information
 ''')
@@ -221,7 +225,8 @@ def strings_to_text(dkeyStrings, dOld, mod_name, header_comments):
 
     for key in dkeyStrings:
         sourceList = list(dkeyStrings[key])
-        sourceList.sort()
+        if params["sort"]:
+            sourceList.sort()
         sourceString = "\n".join(sourceList)
         listForSource = dGroupedBySource.get(sourceString, [])
         listForSource.append(key)

--- a/i18n.py
+++ b/i18n.py
@@ -22,7 +22,8 @@ params = {"recursive": False,
     "verbose": False,
     "folders": [],
     "no-old-file": False,
-    "sort": False,
+    "break-long-lines": False,
+    "sort": False
 }
 # Available CLI options
 options = {"recursive": ['--recursive', '-r'],
@@ -30,13 +31,14 @@ options = {"recursive": ['--recursive', '-r'],
     "mods": ['--installed-mods', '-m'],
     "verbose": ['--verbose', '-v'],
     "no-old-file": ['--no-old-file', '-O'],
-    "sort": ['--sort', '-s'],
+    "break-long-lines": ['--break-long-lines', '-b'],
+    "sort": ['--sort', '-s']
 }
 
 # Strings longer than this will have extra space added between
 # them in the translation files to make it easier to distinguish their
 # beginnings and endings at a glance
-doublespace_threshold = 60
+doublespace_threshold = 80
 
 def set_params_folders(tab: list):
     '''Initialize params["folders"] from CLI arguments.'''
@@ -73,6 +75,8 @@ DESCRIPTION
         do not create *.old files
     {', '.join(options["sort"])}
         sort output strings alphabetically
+    {', '.join(options["break-long-lines"])}
+        add extra line breaks before and after long strings
     {', '.join(options["verbose"])}
         add output information
 ''')
@@ -244,12 +248,12 @@ def strings_to_text(dkeyStrings, dOld, mod_name, header_comments):
             val = dOld.get(localizedString, {})
             translation = val.get("translation", "")
             comment = val.get("comment")
-            if len(localizedString) > doublespace_threshold and not lOut[-1] == "":
+            if params["break-long-lines"] and len(localizedString) > doublespace_threshold and not lOut[-1] == "":
                 lOut.append("")
             if comment != None:
                 lOut.append(comment)
             lOut.append(f"{localizedString}={translation}")
-            if len(localizedString) > doublespace_threshold:
+            if params["break-long-lines"] and len(localizedString) > doublespace_threshold:
                 lOut.append("")
 
 
@@ -265,12 +269,12 @@ def strings_to_text(dkeyStrings, dOld, mod_name, header_comments):
                 if not unusedExist:
                     unusedExist = True
                     lOut.append("\n\n##### not used anymore #####\n")
-                if len(key) > doublespace_threshold and not lOut[-1] == "":
+                if params["break-long-lines"] and len(key) > doublespace_threshold and not lOut[-1] == "":
                     lOut.append("")
                 if comment != None:
                     lOut.append(comment)
                 lOut.append(f"{key}={translation}")
-                if len(key) > doublespace_threshold:
+                if params["break-long-lines"] and len(key) > doublespace_threshold:
                     lOut.append("")
     return "\n".join(lOut) + '\n'
 

--- a/i18n.py
+++ b/i18n.py
@@ -240,7 +240,8 @@ def strings_to_text(dkeyStrings, dOld, mod_name, header_comments):
     lSourceKeys.sort()
     for source in lSourceKeys:
         localizedStrings = dGroupedBySource[source]
-        localizedStrings.sort()
+        if params["sort"]:
+            localizedStrings.sort()
         lOut.append("")
         lOut.append(source)
         lOut.append("")


### PR DESCRIPTION
This adds new parameters:

* `--sort` parameter to sort output alphabetically (disabled by default)
* `--break-long-lines` to enable extra linebreaks before and after long lines (length limit set to 80; disabled by default)
* Short versions of all parameters

Note the 2 new parameters do not implement new features, but rather make it possible to choose *not* to use these features, as I think they can be quite annoying.