### PR TITLE
Don't add string source comments by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ i18n.py [OPTIONS] [PATHS...]
 --no-old-file, -O: do not create *.old files
 --sort, -s: sort output strings alphabetically
 --break-long-lines, -b: add extra line-breaks before and after long strings
+--print-source, -p: add comments denoting the soure file
 --verbose, -v: add output information
 ```
 

--- a/bash-completion/completions/i18n
+++ b/bash-completion/completions/i18n
@@ -2,7 +2,7 @@
 _i18n_completions()
 {
 	local cur OPTS_ALL
-	local hasInstalledModOpt hasRecursiveOpt hasVerboseOpt hasNoOldFileOpt hasSortOpt hasBreakLongLinesOpt
+	local hasInstalledModOpt hasRecursiveOpt hasVerboseOpt hasNoOldFileOpt hasSortOpt hasBreakLongLinesOpt hasPrintSourceOpt
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	for opt in "${COMP_WORDS[@]}"
@@ -29,7 +29,9 @@ _i18n_completions()
 			'-b'|'--break-long-lines')
 				hasBreakLongLinesOpt=1
 				;;
-
+			'-p'|'--print-source')
+				hasPrintSourceOpt=1
+				;;
 		esac
 	done
 	case $cur in
@@ -40,7 +42,8 @@ _i18n_completions()
 				--verbose
 				--no-old-file
 				--sort
-				--break-long-lines"
+				--break-long-lines
+				--print-source"
 
 			# recursive and installed-mods
 			# are mutually exclusives
@@ -64,6 +67,10 @@ _i18n_completions()
 			if [ $hasBreakLongLinesOpt ]
 			then
 				OPTS_ALL=${OPTS_ALL//"--break-long-lines"/}
+			fi
+			if [ $hasPrintSourceOpt]
+			then
+				OPTS_ALL=${OPTS_ALL//"--print-source"/}
 			fi
 
 			COMPREPLY=( $(compgen -W "${OPTS_ALL[*]}" -- $cur) )

--- a/i18n.py
+++ b/i18n.py
@@ -23,7 +23,8 @@ params = {"recursive": False,
     "folders": [],
     "no-old-file": False,
     "break-long-lines": False,
-    "sort": False
+    "sort": False,
+    "print-source": False
 }
 # Available CLI options
 options = {"recursive": ['--recursive', '-r'],
@@ -32,7 +33,8 @@ options = {"recursive": ['--recursive', '-r'],
     "verbose": ['--verbose', '-v'],
     "no-old-file": ['--no-old-file', '-O'],
     "break-long-lines": ['--break-long-lines', '-b'],
-    "sort": ['--sort', '-s']
+    "sort": ['--sort', '-s'],
+    "print-source": ['--print-source', '-p']
 }
 
 # Strings longer than this will have extra space added between
@@ -229,7 +231,7 @@ def mkdir_p(path):
 # dOld is a dictionary of existing translations and comments from
 # the previous version of this text
 def strings_to_text(dkeyStrings, dOld, mod_name, header_comments):
-    lOut = [f"# textdomain: {mod_name}\n"]
+    lOut = [f"# textdomain: {mod_name}"]
     if header_comments is not None:
         lOut.append(header_comments)
     
@@ -250,16 +252,17 @@ def strings_to_text(dkeyStrings, dOld, mod_name, header_comments):
         localizedStrings = dGroupedBySource[source]
         if params["sort"]:
             localizedStrings.sort()
-        lOut.append("")
-        lOut.append(source)
-        lOut.append("")
+        if params["print-source"]:
+            if lOut[-1] != "":
+                lOut.append("")
+            lOut.append(source)
         for localizedString in localizedStrings:
             val = dOld.get(localizedString, {})
             translation = val.get("translation", "")
             comment = val.get("comment")
             if params["break-long-lines"] and len(localizedString) > doublespace_threshold and not lOut[-1] == "":
                 lOut.append("")
-            if comment != None:
+            if comment != None and comment != "" and not comment.startswith("# textdomain:"):
                 lOut.append(comment)
             lOut.append(f"{localizedString}={translation}")
             if params["break-long-lines"] and len(localizedString) > doublespace_threshold:


### PR DESCRIPTION
This PR will disable the addition of comments that show the source file of strings as it might be a bit annoying.

There is now a new switch `-p` that can be used to manually enable these comments again.